### PR TITLE
fix: Add Missing logout in signup tests to reset user session

### DIFF
--- a/app/modules/auth/tests/test_unit.py
+++ b/app/modules/auth/tests/test_unit.py
@@ -73,6 +73,7 @@ def test_signup_user_successful(test_client):
         follow_redirects=True,
     )
     assert response.request.path == url_for("public.index"), "Signup was unsuccessful"
+    test_client.get("/logout", follow_redirects=True)
 
 
 def test_service_create_with_profie_success(clean_database):


### PR DESCRIPTION
In the auth module unit tests, there is an issue in the signup tests where the user session is not reset after successfully signing up, which causes unexpected behavior in subsequent tests. This happens because, during a successful signup, the login_user() function is called, leaving the user logged in. However, unlike the login tests, there is no logout action to clear the session after each signup test. 
I added a test_client.get("/logout", follow_redirects=True) call after the assertions in the signup tests, ensuring that each following test starts with an  unauthenticated session.