### PR TITLE
feat(dataset): add import UVL models from GitHub and ZIP

### DIFF
--- a/app/modules/dataset/assets/scripts.js
+++ b/app/modules/dataset/assets/scripts.js
@@ -237,3 +237,371 @@ var currentId = 0;
             let orcidRegex = /^\d{4}-\d{4}-\d{4}-\d{4}$/;
             return orcidRegex.test(orcid);
         }
+
+function showAlert(container, message, type) {
+    if (!container) return;
+
+    const alertDiv = document.createElement('div');
+    alertDiv.className = `alert alert-${type} alert-dismissible fade show`;
+    alertDiv.setAttribute('role', 'alert');
+    alertDiv.innerHTML = `
+        ${message}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    `;
+
+    container.innerHTML = '';
+    container.appendChild(alertDiv);
+}
+
+function displayImportedFiles(source, files) {
+    const fileList = document.getElementById('file-list');
+    if (!fileList) {
+        console.warn('file-list container not found');
+        return;
+    }
+
+    files.forEach(filename => {
+        const fileId = generateIncrementalId();
+
+        const listItem = document.createElement('li');
+        const h4Element = document.createElement('h4');
+        h4Element.textContent = filename;
+        listItem.appendChild(h4Element);
+
+        // Info button
+        const formButton = document.createElement('button');
+        formButton.innerHTML = 'Show info';
+        formButton.classList.add('info-button', 'btn', 'btn-outline-secondary', 'btn-sm');
+        formButton.style.borderRadius = '5px';
+        formButton.id = fileId + "_button";
+
+        // Form container 
+        const formContainer = document.createElement('div');
+        formContainer.id = fileId + "_form";
+        formContainer.classList.add('uvl_form', 'mt-3');
+        formContainer.style.display = "none";
+
+        formButton.addEventListener('click', function() {
+            if (formContainer.style.display === "none") {
+                formContainer.style.display = "block";
+                formButton.innerHTML = 'Hide info';
+            } else {
+                formContainer.style.display = "none";
+                formButton.innerHTML = 'Add info';
+            }
+        });
+
+        // Space
+        listItem.appendChild(document.createTextNode(" "));
+
+        // Remove button
+        const removeButton = document.createElement('button');
+        removeButton.innerHTML = 'Delete model';
+        removeButton.classList.add('remove-button', 'btn', 'btn-outline-danger', 'btn-sm');
+        removeButton.style.borderRadius = '5px';
+
+        removeButton.addEventListener('click', function() {
+            // Remove from DOM
+            fileList.removeChild(listItem);
+
+            // Delete from server
+            fetch('/dataset/file/delete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ file: filename })
+            });
+
+            // Hide upload button if no files left
+            if (fileList.children.length === 0) {
+                document.getElementById("upload_dataset").style.display = "none";
+                clean_upload_errors();
+            }
+        });
+
+        listItem.appendChild(document.createTextNode(" "));
+        listItem.appendChild(formButton);
+        listItem.appendChild(removeButton);
+
+        // UVL form 
+        formContainer.innerHTML = `
+            <div class="row">
+                <input type="hidden" value="${filename}" name="feature_models-${fileId}-uvl_filename">
+                <div class="col-12">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="mb-3">
+                                <label class="form-label">Title</label>
+                                <input type="text" class="form-control" name="feature_models-${fileId}-title">
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <div class="mb-3">
+                                <label class="form-label">Description</label>
+                                <textarea rows="4" class="form-control" name="feature_models-${fileId}-desc"></textarea>
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-12">
+                            <div class="mb-3">
+                                <label class="form-label">Publication type</label>
+                                <select class="form-control" name="feature_models-${fileId}-publication_type">
+                                    <option value="none">None</option>
+                                    <option value="annotationcollection">Annotation Collection</option>
+                                    <option value="book">Book</option>
+                                    <option value="section">Book Section</option>
+                                    <option value="conferencepaper">Conference Paper</option>
+                                    <option value="datamanagementplan">Data Management Plan</option>
+                                    <option value="article">Journal Article</option>
+                                    <option value="patent">Patent</option>
+                                    <option value="preprint">Preprint</option>
+                                    <option value="deliverable">Project Deliverable</option>
+                                    <option value="milestone">Project Milestone</option>
+                                    <option value="proposal">Proposal</option>
+                                    <option value="report">Report</option>
+                                    <option value="softwaredocumentation">Software Documentation</option>
+                                    <option value="taxonomictreatment">Taxonomic Treatment</option>
+                                    <option value="technicalnote">Technical Note</option>
+                                    <option value="thesis">Thesis</option>
+                                    <option value="workingpaper">Working Paper</option>
+                                    <option value="other">Other</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-6">
+                            <div class="mb-3">
+                                <label class="form-label">Publication DOI</label>
+                                <input class="form-control" name="feature_models-${fileId}-publication_doi" type="text">
+                            </div>
+                        </div>
+                        <div class="col-6">
+                            <div class="mb-3">
+                                <label class="form-label">Tags (separated by commas)</label>
+                                <input type="text" class="form-control" name="feature_models-${fileId}-tags">
+                            </div>
+                        </div>
+                        <div class="col-6">
+                            <div class="mb-3">
+                                <label class="form-label">UVL version</label>
+                                <input type="text" class="form-control" name="feature_models-${fileId}-uvl_version">
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <div class="mb-3">
+                                <label class="form-label">Authors</label>
+                                <div id="${formContainer.id}_authors"></div>
+                                <button type="button" class="add_author_to_uvl btn btn-secondary" id="${formContainer.id}_authors_button">Add author</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        listItem.appendChild(formContainer);
+        fileList.appendChild(listItem);
+    });
+
+    if (typeof feather !== 'undefined') {
+        feather.replace();
+    }
+
+    show_upload_dataset();
+}
+
+// ========================================
+// IMPORT FROM GITHUB
+// ========================================
+document.addEventListener('DOMContentLoaded', function() {
+    const githubBtn = document.getElementById('import_github_btn');
+
+    if (githubBtn) {
+        githubBtn.addEventListener('click', function() {
+            const githubUrlInput = document.getElementById('github_url');
+            const githubUrl = githubUrlInput ? githubUrlInput.value.trim() : '';
+
+            // Find or create alerts container
+            let alertsContainer = document.getElementById('github-alerts');
+            if (!alertsContainer) {
+                alertsContainer = document.createElement('div');
+                alertsContainer.id = 'github-alerts';
+                alertsContainer.className = 'mt-3';
+                const cardBody = githubBtn.closest('.card-body');
+                if (cardBody) {
+                    cardBody.insertBefore(alertsContainer, cardBody.firstChild);
+                }
+            }
+
+            // Basic validation
+            if (!githubUrl) {
+                showAlert(alertsContainer, 'Please enter a GitHub URL', 'danger');
+                return;
+            }
+
+            if (!githubUrl.includes('github.com')) {
+                showAlert(alertsContainer, 'Invalid GitHub URL', 'danger');
+                return;
+            }
+
+            // Disable button and show loading
+            const originalHTML = githubBtn.innerHTML;
+            githubBtn.disabled = true;
+            githubBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Importing...';
+
+            // Clear previous alerts
+            alertsContainer.innerHTML = '';
+
+            // Call the import endpoint
+            fetch('/dataset/import', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ github_url: githubUrl })
+            })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(err => Promise.reject(err));
+                }
+                return response.json();
+            })
+            .then(data => {
+                githubBtn.disabled = false;
+                githubBtn.innerHTML = originalHTML;
+
+                if (typeof feather !== 'undefined') {
+                    feather.replace();
+                }
+
+                if (data.files && data.files.length > 0) {
+                    showAlert(alertsContainer,
+                        `Successfully imported ${data.count} UVL file(s) from GitHub`,
+                        'success'
+                    );
+
+                    // Display imported files
+                    displayImportedFiles('github', data.files);
+
+                    // Clear the input
+                    if (githubUrlInput) {
+                        githubUrlInput.value = '';
+                    }
+
+                    // Show upload dataset button
+                    show_upload_dataset();
+                } else {
+                    showAlert(alertsContainer, data.message || 'No files imported', 'warning');
+                }
+            })
+            .catch(error => {
+                githubBtn.disabled = false;
+                githubBtn.innerHTML = originalHTML;
+
+                if (typeof feather !== 'undefined') {
+                    feather.replace();
+                }
+
+                const errorMsg = error.message || 'Failed to import from GitHub';
+                showAlert(alertsContainer, errorMsg, 'danger');
+            });
+        });
+    }
+});
+
+
+// ========================================
+// IMPORT FROM ZIP
+// ========================================
+document.addEventListener('DOMContentLoaded', function() {
+    const zipBtn = document.getElementById('import_zip_btn');
+
+    if (zipBtn) {
+        zipBtn.addEventListener('click', function() {
+            const zipFileInput = document.getElementById('zip_file');
+
+            // Find or create alerts container
+            let alertsContainer = document.getElementById('zip-alerts');
+            if (!alertsContainer) {
+                alertsContainer = document.createElement('div');
+                alertsContainer.id = 'zip-alerts';
+                alertsContainer.className = 'mt-3';
+                const cardBody = zipBtn.closest('.card-body');
+                if (cardBody) {
+                    cardBody.insertBefore(alertsContainer, cardBody.firstChild);
+                }
+            }
+
+            // Basic validation
+            if (!zipFileInput || !zipFileInput.files || zipFileInput.files.length === 0) {
+                showAlert(alertsContainer, 'Please select a ZIP file', 'danger');
+                return;
+            }
+
+            const file = zipFileInput.files[0];
+
+            if (!file.name.toLowerCase().endsWith('.zip')) {
+                showAlert(alertsContainer, 'Only ZIP files are allowed', 'danger');
+                return;
+            }
+
+            // Disable button and show loading
+            const originalHTML = zipBtn.innerHTML;
+            zipBtn.disabled = true;
+            zipBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Importing...';
+
+            // Clear previous alerts
+            alertsContainer.innerHTML = '';
+
+            // Prepare form data
+            const formData = new FormData();
+            formData.append('file', file);
+
+            // Call the import endpoint
+            fetch('/dataset/import', {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(err => Promise.reject(err));
+                }
+                return response.json();
+            })
+            .then(data => {
+                zipBtn.disabled = false;
+                zipBtn.innerHTML = originalHTML;
+
+                if (typeof feather !== 'undefined') {
+                    feather.replace();
+                }
+
+                if (data.files && data.files.length > 0) {
+                    showAlert(alertsContainer,
+                        `Successfully imported ${data.count} UVL file(s) from ZIP`,
+                        'success'
+                    );
+
+                    // Display imported files
+                    displayImportedFiles('zip', data.files);
+
+                    // Clear the file input
+                    zipFileInput.value = '';
+
+                    // Show upload dataset button
+                    show_upload_dataset();
+                } else {
+                    showAlert(alertsContainer, data.message || 'No files imported', 'warning');
+                }
+            })
+            .catch(error => {
+                zipBtn.disabled = false;
+                zipBtn.innerHTML = originalHTML;
+
+                if (typeof feather !== 'undefined') {
+                    feather.replace();
+                }
+
+                const errorMsg = error.message || 'Failed to import from ZIP';
+                showAlert(alertsContainer, errorMsg, 'danger');
+            });
+        });
+    }
+});

--- a/app/modules/dataset/fetchers/__init__.py
+++ b/app/modules/dataset/fetchers/__init__.py
@@ -1,0 +1,5 @@
+from .base import Fetcher_Interface, FetchError
+from .github import GithubFetcher
+from .registry import DataSourceManager
+
+__all__ = ["Fetcher_Interface", "FetchError", "GithubFetcher", "DataSourceManager"]

--- a/app/modules/dataset/fetchers/base.py
+++ b/app/modules/dataset/fetchers/base.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class FetchError(RuntimeError):
+    pass
+
+
+class Fetcher_Interface(ABC):
+    @abstractmethod
+    def supports(self, url): ...
+
+    @abstractmethod
+    def fetch(self, url, dest_root, current_user=None): ...

--- a/app/modules/dataset/fetchers/github.py
+++ b/app/modules/dataset/fetchers/github.py
@@ -1,0 +1,69 @@
+import logging
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+
+from git import GitCommandError, Repo
+
+from .base import Fetcher_Interface, FetchError
+
+logger = logging.getLogger(__name__)
+
+
+class GithubFetcher(Fetcher_Interface):
+    def supports(self, url):
+        try:
+            return urlparse(url).netloc == "github.com"
+        except Exception:
+            return False
+
+    def fetch(self, url, dest_root, current_user=None):
+        owner, repo, branch, subpath = self._parse_github_url(url)
+        if not owner or not repo:
+            raise FetchError(f"Invalid GitHub URL: {url}")
+
+        tmp_dir = Path(tempfile.mkdtemp(dir=dest_root))
+        repo_dir = tmp_dir / f"{owner}__{repo}"
+
+        clone_url = f"https://github.com/{owner}/{repo}.git"
+        logger.info(f"[GitHubFetcher] Cloning {clone_url} into {repo_dir}")
+
+        try:
+            if branch:
+                Repo.clone_from(clone_url, repo_dir, depth=1, branch=branch)
+            else:
+                Repo.clone_from(clone_url, repo_dir, depth=1)
+        except GitCommandError as e:
+            raise FetchError(f"Failed to clone repository: {e}")
+
+        if subpath:
+            target = repo_dir / subpath
+            if not target.exists():
+                raise FetchError("The requested subfolder does not exist in the repository")
+            return target
+
+        return repo_dir
+
+    def _parse_github_url(self, url):
+
+        parts = urlparse(url)
+        if parts.netloc != "github.com":
+            return None, None, None, None
+
+        segments = [s for s in parts.path.split("/") if s]
+        if len(segments) < 2:
+            return None, None, None, None
+
+        owner, repo = segments[0], segments[1]
+        if repo.endswith(".git"):
+            repo = repo[:-4]
+
+        branch = None
+        subpath = None
+
+        if len(segments) >= 4 and segments[2] == "tree":
+            branch = segments[3]
+            if len(segments) > 4:
+                subpath = "/".join(segments[4:])
+
+        return owner, repo, branch, subpath

--- a/app/modules/dataset/fetchers/registry.py
+++ b/app/modules/dataset/fetchers/registry.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from .base import FetchError
+
+
+class DataSourceManager:
+    def __init__(self, providers):
+        self.providers = list(providers)
+
+    def fetch_to_user_temp(self, url, current_user):
+        dest_root = Path(current_user.temp_folder())
+        dest_root.mkdir(parents=True, exist_ok=True)
+
+        for p in self.providers:
+            if p.supports(url):
+                return p.fetch(url, dest_root, current_user=current_user)
+
+        raise FetchError(f"No provider supports this URL: {url}")

--- a/app/modules/dataset/fetchers/zip.py
+++ b/app/modules/dataset/fetchers/zip.py
@@ -1,0 +1,99 @@
+# app/modules/dataset/fetchers/zip.py
+
+import logging
+import posixpath
+import shutil
+import tempfile
+from pathlib import Path
+from zipfile import BadZipFile, ZipFile
+
+from .base import Fetcher_Interface, FetchError
+
+logger = logging.getLogger(__name__)
+
+
+class ZipFetcher(Fetcher_Interface):
+    EXTRACTABLE_EXTS = {".uvl"}
+    MAX_ZIP_ENTRIES = 500
+
+    def supports(self, url):
+        try:
+            return str(url).lower().endswith(".zip")
+        except Exception:
+            return False
+
+    def fetch(self, url, dest_root, current_user=None):
+        zip_path = Path(str(url))
+
+        if not zip_path.exists():
+            raise FetchError(f"ZIP file not found: {zip_path}")
+
+        extract_root = Path(tempfile.mkdtemp(dir=dest_root, prefix="zip_"))
+        logger.info(f"[ZipFetcher] Extracting {zip_path} into {extract_root}")
+
+        extracted_any = False
+
+        try:
+            with ZipFile(zip_path, "r") as zf:
+                infos = zf.infolist()
+                if len(infos) > self.MAX_ZIP_ENTRIES:
+                    raise FetchError("ZIP has too many entries")
+
+                def safe_extract(member):
+                    nonlocal extracted_any
+
+                    if member.is_dir():
+                        return None
+
+                    raw_path = member.filename
+                    norm_path = posixpath.normpath(raw_path)
+
+                    if norm_path.startswith("/") or norm_path.startswith("..") or "/.." in norm_path:
+                        raise FetchError("Unsafe path in ZIP")
+
+                    ext = Path(norm_path).suffix.lower()
+                    if ext not in self.EXTRACTABLE_EXTS:
+                        return None
+
+                    desired_name = Path(norm_path).name
+                    target = extract_root / desired_name
+
+                    i = 1
+                    while target.exists():
+                        stem = Path(desired_name).stem
+                        suffix = Path(desired_name).suffix
+                        target = extract_root / f"{stem} ({i}){suffix}"
+                        i += 1
+
+                    resolved = target.resolve()
+                    base_resolved = extract_root.resolve()
+                    if base_resolved not in resolved.parents and base_resolved != resolved:
+                        raise FetchError("Unsafe path in ZIP")
+
+                    with zf.open(member, "r") as src, open(resolved, "wb") as dst:
+                        shutil.copyfileobj(src, dst)
+
+                    extracted_any = True
+                    return resolved
+
+                for info in infos:
+                    safe_extract(info)
+
+        except BadZipFile:
+            raise FetchError("Invalid ZIP file")
+        finally:
+            try:
+                if zip_path.exists() and zip_path.is_file():
+                    zip_path.unlink()
+            except Exception:
+                pass
+
+        if not extracted_any:
+            try:
+                extract_root.rmdir()
+            except OSError:
+                pass
+            raise FetchError("ZIP processed, but no .uvl files were found")
+
+        logger.info(f"[ZipFetcher] Extraction completed into {extract_root}")
+        return extract_root

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -22,6 +22,7 @@ from flask_login import current_user, login_required
 from app.modules.dataset import dataset_bp
 from app.modules.dataset.forms import DataSetForm
 from app.modules.dataset.models import DSDownloadRecord
+from app.modules.dataset.fetchers.base import FetchError
 from app.modules.dataset.services import (
     AuthorService,
     DataSetService,
@@ -30,6 +31,7 @@ from app.modules.dataset.services import (
     DSMetaDataService,
     DSViewRecordService,
 )
+from pathlib import Path
 from app.modules.zenodo.services import ZenodoService
 
 logger = logging.getLogger(__name__)
@@ -170,6 +172,68 @@ def delete():
         return jsonify({"message": "File deleted successfully"})
 
     return jsonify({"error": "Error: File not found"})
+
+
+# ==================== IMPORT FROM GITHUB / ZIP ====================
+
+
+@dataset_bp.route("/dataset/import", methods=["POST"])
+@login_required
+def import_dataset():
+    """
+    Import UVL models from:
+    - GitHub repository URL (github_url)
+    - Uploaded ZIP file (file)
+    Files are saved to the user's temp folder.
+    """
+    json_data = request.get_json(silent=True) or {}
+    form_data = request.form or {}
+
+    github_url = json_data.get("github_url") or form_data.get("github_url")
+    zip_file = request.files.get("file")
+
+    if github_url and zip_file:
+        return jsonify({"message": "Provide either 'github_url' or a ZIP file, not both"}), 400
+    if not github_url and not zip_file:
+        return jsonify({"message": "Provide 'github_url' or a ZIP file"}), 400
+
+    temp_folder = Path(current_user.temp_folder())
+    temp_folder.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if github_url:
+            added = dataset_service.fetch_models_from_github(
+                github_url=github_url,
+                dest_dir=temp_folder,
+                current_user=current_user,
+            )
+        else:
+            added = dataset_service.fetch_models_from_zip_upload(
+                file_storage=zip_file,
+                dest_dir=temp_folder,
+                current_user=current_user,
+            )
+
+        if not added:
+            return jsonify({"message": "No .uvl files found"}), 400
+
+        return (
+            jsonify(
+                {
+                    "message": "UVL models imported successfully",
+                    "files": [p.name for p in added],
+                    "count": len(added),
+                }
+            ),
+            200,
+        )
+
+    except FetchError as fe:
+        logger.warning(f"FetchError importing models: {fe}")
+        return jsonify({"message": str(fe)}), 400
+    except Exception as exc:
+        logger.exception(f"Error importing models: {exc}")
+        return jsonify({"message": "Internal server error"}), 500
 
 
 @dataset_bp.route("/dataset/download/<int:dataset_id>", methods=["GET"])

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -2,12 +2,19 @@ import hashlib
 import logging
 import os
 import shutil
+import tempfile
 import uuid
+from pathlib import Path
 from typing import Optional
+from zipfile import ZipFile
 
 from flask import request
 
 from app.modules.auth.services import AuthenticationService
+from app.modules.dataset.fetchers.base import FetchError
+from app.modules.dataset.fetchers.github import GithubFetcher
+from app.modules.dataset.fetchers.registry import DataSourceManager
+from app.modules.dataset.fetchers.zip import ZipFetcher
 from app.modules.dataset.models import DataSet, DSMetaData, DSViewRecord
 from app.modules.dataset.repositories import (
     AuthorRepository,
@@ -48,6 +55,14 @@ class DataSetService(BaseService):
         self.hubfilerepository = HubfileRepository()
         self.dsviewrecord_repostory = DSViewRecordRepository()
         self.hubfileviewrecord_repository = HubfileViewRecordRepository()
+
+        # Initialize data source manager for GitHub/ZIP imports
+        self.datasource_manager = DataSourceManager(
+            providers=[
+                GithubFetcher(),
+                ZipFetcher(),
+            ]
+        )
 
     def move_feature_models(self, dataset: DataSet):
         current_user = AuthenticationService().get_authenticated_user()
@@ -139,6 +154,117 @@ class DataSetService(BaseService):
     def get_uvlhub_doi(self, dataset: DataSet) -> str:
         domain = os.getenv("DOMAIN", "localhost")
         return f"http://{domain}/doi/{dataset.ds_meta_data.dataset_doi}"
+
+    # ==================== IMPORT FROM GITHUB / ZIP ====================
+
+    def _save_zip_to_temp(self, file_storage, current_user) -> Path:
+        """
+        Validates and saves the uploaded ZIP file to user's temp folder.
+        Returns the path to the saved file.
+        """
+        if not file_storage or not file_storage.filename:
+            raise FetchError("No ZIP file provided")
+
+        filename = file_storage.filename
+        if not filename.lower().endswith(".zip"):
+            raise FetchError("Invalid file type. Only .zip allowed")
+
+        user_temp = Path(current_user.temp_folder())
+        user_temp.mkdir(parents=True, exist_ok=True)
+
+        base_name = Path(filename).name
+        target = user_temp / base_name
+
+        # Avoid overwriting existing files
+        i = 1
+        while target.exists():
+            stem = Path(base_name).stem
+            suffix = Path(base_name).suffix
+            target = user_temp / f"{stem} ({i}){suffix}"
+            i += 1
+
+        file_storage.save(str(target))
+        return target
+
+    def _collect_uvl_files_into_temp(self, source_root: Path, dest_dir: Path):
+        """
+        Copies all valid .uvl files from source_root to dest_dir.
+        Also extracts and processes any ZIP files found inside.
+        Returns list of copied file paths.
+        """
+        added = []
+
+        for path in Path(source_root).rglob("*"):
+            if not path.is_file():
+                continue
+
+            # Process nested ZIP files
+            if path.suffix.lower() == ".zip":
+                logger.info(f"Found nested ZIP file: {path.name}, extracting...")
+
+                try:
+                    with tempfile.TemporaryDirectory() as temp_extract_dir:
+                        temp_extract_path = Path(temp_extract_dir)
+
+                        with ZipFile(path, "r") as zip_ref:
+                            for zip_info in zip_ref.infolist():
+                                # Security: prevent path traversal attacks
+                                if zip_info.filename.startswith("/") or ".." in zip_info.filename:
+                                    logger.warning(f"Skipping dangerous path in ZIP: {zip_info.filename}")
+                                    continue
+                                zip_ref.extract(zip_info, temp_extract_path)
+
+                        # Recursively search for UVL files inside extracted ZIP
+                        zip_models = self._collect_uvl_files_into_temp(temp_extract_path, dest_dir)
+                        added.extend(zip_models)
+
+                        logger.info(f"Found {len(zip_models)} UVL files inside {path.name}")
+
+                except Exception as e:
+                    logger.warning(f"Could not process nested ZIP {path.name}: {e}")
+                continue
+
+            # Only process .uvl files (skip macOS metadata files starting with ._)
+            if path.suffix.lower() != ".uvl":
+                continue
+
+            if path.name.startswith("._"):
+                logger.debug(f"Skipping macOS metadata file: {path.name}")
+                continue
+
+            # Validate UVL file has content
+            if path.stat().st_size == 0:
+                logger.warning(f"Skipping empty file: {path.name}")
+                continue
+
+            # Copy to destination, avoiding name collisions
+            dest_path = dest_dir / path.name
+            counter = 1
+            while dest_path.exists():
+                stem = path.stem
+                dest_path = dest_dir / f"{stem}_{counter}.uvl"
+                counter += 1
+
+            shutil.copy2(path, dest_path)
+            added.append(dest_path)
+            logger.info(f"Imported UVL file: {path.name}")
+
+        return added
+
+    def fetch_models_from_github(self, github_url: str, dest_dir: Path, current_user):
+        """
+        Clones/downloads GitHub repository to user's temp folder and copies .uvl files to dest_dir.
+        """
+        base_path = self.datasource_manager.fetch_to_user_temp(github_url, current_user)
+        return self._collect_uvl_files_into_temp(base_path, dest_dir)
+
+    def fetch_models_from_zip_upload(self, file_storage, dest_dir: Path, current_user):
+        """
+        Saves uploaded ZIP, extracts it, and copies .uvl files to dest_dir.
+        """
+        zip_path = self._save_zip_to_temp(file_storage, current_user)
+        extracted_root = self.datasource_manager.fetch_to_user_temp(str(zip_path), current_user)
+        return self._collect_uvl_files_into_temp(extracted_root, dest_dir)
 
 
 class AuthorService(BaseService):

--- a/app/modules/dataset/templates/dataset/blocks/upload_github.html
+++ b/app/modules/dataset/templates/dataset/blocks/upload_github.html
@@ -1,0 +1,44 @@
+<div class="card mb-4 border-primary">
+    <div class="card-header bg-primary text-white">
+        <h5 class="mb-0">
+            <i data-feather="github"></i>
+            Import from GitHub
+        </h5>
+    </div>
+    <div class="card-body">
+        <p class="text-muted">
+            Import UVL files directly from a GitHub repository.
+            The system will automatically detect and import all .uvl files.
+        </p>
+
+        <div id="github-alerts"></div>
+
+        <div class="mb-3">
+            <label for="github_url" class="form-label">GitHub Repository URL *</label>
+            <input type="text"
+                   class="form-control"
+                   id="github_url"
+                   placeholder="https://github.com/owner/repo"
+                   required>
+            <div class="form-text">
+                <strong>Supported formats:</strong>
+                <ul class="mb-0">
+                    <li><code>https://github.com/owner/repo</code></li>
+                    <li><code>https://github.com/owner/repo/tree/branch</code></li>
+                    <li><code>https://github.com/owner/repo/tree/branch/path/to/folder</code></li>
+                </ul>
+            </div>
+        </div>
+
+        <button type="button"
+                class="btn btn-primary"
+                id="import_github_btn">
+            <i data-feather="download"></i> Import from GitHub
+        </button>
+
+        <div id="github-imported-files" class="mt-4" style="display: none;">
+            <h6>Imported Files:</h6>
+            <ul id="github-file-list" class="list-unstyled"></ul>
+        </div>
+    </div>
+</div>

--- a/app/modules/dataset/templates/dataset/blocks/upload_zip.html
+++ b/app/modules/dataset/templates/dataset/blocks/upload_zip.html
@@ -1,0 +1,39 @@
+<div class="card mb-4 border-warning">
+    <div class="card-header bg-warning text-dark">
+        <h5 class="mb-0">
+            <i data-feather="package"></i>
+            Import from ZIP
+        </h5>
+    </div>
+    <div class="card-body">
+        <p class="text-muted">
+            Upload a ZIP file containing UVL files.
+            Files can be in the root or nested in subdirectories.
+        </p>
+
+        <div id="zip-alerts"></div>
+
+        <div class="mb-3">
+            <label for="zip_file" class="form-label">ZIP File *</label>
+            <input type="file"
+                   class="form-control"
+                   id="zip_file"
+                   accept=".zip"
+                   required>
+            <div class="form-text">
+                Maximum file size: <strong>100 MB</strong>
+            </div>
+        </div>
+
+        <button type="button"
+                class="btn btn-warning"
+                id="import_zip_btn">
+            <i data-feather="upload"></i> Import from ZIP
+        </button>
+
+        <div id="zip-imported-files" class="mt-4" style="display: none;">
+            <h6>Imported Files:</h6>
+            <ul id="zip-file-list" class="list-unstyled"></ul>
+        </div>
+    </div>
+</div>

--- a/app/modules/dataset/templates/dataset/upload_dataset.html
+++ b/app/modules/dataset/templates/dataset/upload_dataset.html
@@ -446,6 +446,15 @@
                 </script>
 
             </div>
+
+            <!-- Alternative import options -->
+            <h1 class="h3 mb-3 mt-4">Alternative import options</h1>
+
+            <div style="padding-left: 2rem">
+                {% include 'dataset/blocks/upload_github.html' %}
+                {% include 'dataset/blocks/upload_zip.html' %}
+            </div>
+
         </div>
 
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.2.2
 gevent==25.5.1
 geventhttpclient==2.3.4
+GitPython==3.1.43
 graphviz==0.21
 greenlet==3.2.3
 gunicorn==23.0.0


### PR DESCRIPTION
This PR adds the ability to import UVL feature models from external sources:                       
                                                                                                     
  - GitHub import: Clone repositories and extract .uvl files (supports branch/subfolder URLs)    
  - ZIP import: Upload ZIP files containing .uvl models (supports nested ZIPs)                 